### PR TITLE
Improved timer metrics

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -213,14 +213,38 @@ function add_statsd_monitor(name, type, res_cb) {
     result_params_stage.push({
       name: 'sum',
       displayName: 'sum',
-      uom: '',
+      uom: 'ms',
+      dataType: 2
+    });
+    result_params_stage.push({
+      name: 'mean',
+      displayName: 'mean',
+      uom: 'ms',
       dataType: 4
     });
     result_params_stage.push({
-      name: 'avg',
-      displayName: 'avg',
+      name: 'upper',
+      displayName: 'upper',
+      uom: 'ms',
+      dataType: 2
+    });
+    result_params_stage.push({
+      name: 'lower',
+      displayName: 'lower',
+      uom: 'ms',
+      dataType: 2
+    });
+    result_params_stage.push({
+      name: 'upper_90',
+      displayName: 'upper_90',
+      uom: 'ms',
+      dataType: 2
+    });
+    result_params_stage.push({
+      name: 'count',
+      displayName: 'count',
       uom: '',
-      dataType: 4
+      dataType: 2
     });
   }
   else {

--- a/backend.js
+++ b/backend.js
@@ -27,9 +27,6 @@ function monitis_flush(ts, metrics) {
   var key,    // iteration over members of metrics
     name,     // iteration over metrics.raws
     value,
-    sum,      // iteration over metrics.timers
-    avg,
-    times,
     i;        // iteration in for loop
 
   console.log("Called flush_stats");
@@ -55,18 +52,12 @@ function monitis_flush(ts, metrics) {
     }
   }
   for (key in metrics.timers) {
-    if (metrics.timers.hasOwnProperty(key)) {
-      sum = 0;
-      avg = 0;
-      times = metrics.timers[key];
-      for (i = 0; i < times.length; i++) {
-        sum += times[i];
-      }
-      if (times.length > 0) {
-        avg = sum / times.length;
-      }
+    if (metrics.timer_data.hasOwnProperty(key)) {
+      var data = metrics.timer_data[key]
       monitis.add_result_by_name(key,
-        {sum: sum, avg: avg}, missing_monitor_cb(key, 'timer'));
+        {sum: data.sum, mean: data.mean, upper: data.upper,
+          lower: data.lower, upper_90: data.upper_90, count: data.count},
+        missing_monitor_cb(key, 'timer'));
       util.debug(metrics.timers);
     }
   }

--- a/backend.js
+++ b/backend.js
@@ -87,7 +87,7 @@ exports.init = function monitis_init(startup_time, config, events) {
   // read monitis config
   global.monitis = config.monitis;
   if (!config.monitis.host) {
-    global.monitis.host = 'monitis.com';
+    global.monitis.host = 'api.monitis.com';
   }
   if (!config.monitis.path) {
     global.monitis.path = '/customMonitorApi';


### PR DESCRIPTION
Using the precomputed timer metrics from 'metrics.timer_data' instead of generating them from the raw timer data. The old 'avg' didn't seem to work (always showed up with the value 0 in the Monitis report) so it has been replaced with the standard 'mean' value.

Also updated to the new(?) monitis host, api.monitis.com.
